### PR TITLE
Renaming assests to assets, and excluding index.js from testing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,12 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "sinon": "^7.3.1"
+  },
+  "jest":{
+    "collectCoverageFrom": [
+      "**/*.{js,jsx}",
+      "!src/index.js",
+      "!coverage/**"
+    ]
   }
 }


### PR DESCRIPTION
The assets folder was misspelled and index.js was being included in testing. The file was removed from testing due to the fact that it only mounts the application to a div in the index.html file.